### PR TITLE
add `Smartcalc::App::execute_session`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -101,7 +101,7 @@ impl Session {
         }
     }
 
-    pub(crate) fn set_text(&mut self, text: String) {
+    pub fn set_text(&mut self, text: String) {
         self.text = text;
 
         self.text_parts = match Regex::new(r"\r\n|\n") {

--- a/src/app.rs
+++ b/src/app.rs
@@ -184,7 +184,7 @@ impl Session {
         //self.ui_tokens.sort_by(|a, b| a.start.partial_cmp(&b.start).unwrap());
     }
 
-    pub fn cleanup(&mut self) {
+    pub(crate) fn cleanup(&mut self) {
         self.token_infos.clear();
         self.tokens.clear();
         self.asts.clear();
@@ -439,16 +439,16 @@ impl SmartCalc {
         session.set_language(language.borrow().to_string());
 
         let session = RefCell::new(session);
-        self.execute_session(session)
+        self.execute_session(&session)
     }
 
-    pub fn execute_session(&self, session: RefCell<Session>) -> ExecuteResult {
+    pub fn execute_session(&self, session: &RefCell<Session>) -> ExecuteResult {
         let mut results = ExecuteResult::default();
 
         if session.borrow().has_value() {
             results.status = true;
             loop {
-                let line_result = self.execute_text(&session);
+                let line_result = self.execute_text(session);
                 results.lines.push(line_result);
                 session.borrow_mut().cleanup();
                 if session.borrow().next().is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,24 +12,24 @@ extern crate log;
 #[cfg(all(not(target_arch = "wasm32"), not(test)))]
 extern crate libc_print;
 
-pub(crate) mod types;
-pub(crate) mod tokinizer;
-pub(crate) mod syntax;
-pub(crate) mod worker;
-pub(crate) mod compiler;
-pub(crate) mod constants;
-pub(crate) mod tools;
-pub(crate) mod logger;
-pub(crate) mod formatter;
-pub(crate) mod token;
-pub(crate) mod config;
 pub(crate) mod app;
+pub(crate) mod compiler;
+pub(crate) mod config;
+pub(crate) mod constants;
+pub(crate) mod formatter;
+pub(crate) mod logger;
+pub(crate) mod syntax;
+pub(crate) mod token;
+pub(crate) mod tokinizer;
+pub(crate) mod tools;
+pub(crate) mod types;
+pub(crate) mod worker;
 
 #[cfg(test)]
 mod tests;
 
-pub use app::SmartCalc;
-pub use config::SmartCalcConfig;
-pub use types::SmartCalcAstType;
-pub use types::FieldType;
+pub use app::{Session, SmartCalc};
 pub use compiler::DataItem;
+pub use config::SmartCalcConfig;
+pub use types::FieldType;
+pub use types::SmartCalcAstType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,24 +12,25 @@ extern crate log;
 #[cfg(all(not(target_arch = "wasm32"), not(test)))]
 extern crate libc_print;
 
-pub(crate) mod app;
-pub(crate) mod compiler;
-pub(crate) mod config;
-pub(crate) mod constants;
-pub(crate) mod formatter;
-pub(crate) mod logger;
-pub(crate) mod syntax;
-pub(crate) mod token;
-pub(crate) mod tokinizer;
-pub(crate) mod tools;
 pub(crate) mod types;
+pub(crate) mod tokinizer;
+pub(crate) mod syntax;
 pub(crate) mod worker;
+pub(crate) mod compiler;
+pub(crate) mod constants;
+pub(crate) mod tools;
+pub(crate) mod logger;
+pub(crate) mod formatter;
+pub(crate) mod token;
+pub(crate) mod config;
+pub(crate) mod app;
 
 #[cfg(test)]
 mod tests;
 
-pub use app::{Session, SmartCalc};
-pub use compiler::DataItem;
+pub use app::SmartCalc;
+pub use app::Session;
 pub use config::SmartCalcConfig;
-pub use types::FieldType;
 pub use types::SmartCalcAstType;
+pub use types::FieldType;
+pub use compiler::DataItem;

--- a/src/tests/executer_test.rs
+++ b/src/tests/executer_test.rs
@@ -670,7 +670,7 @@ macro_rules! evaluate_line {
     };
     ($calc:ident with $session:ident, $input:literal => Err) => {
         $session.borrow_mut().set_text($input.to_string());
-        let res = $calc.execute("en".to_string(), $input.to_string());
+        let res = $calc.execute_session(&$session);
         assert_eq!(res.lines.len(), 1);
         assert!(res.lines[0].as_ref().unwrap().result.as_ref().is_err());
     };

--- a/src/tests/executer_test.rs
+++ b/src/tests/executer_test.rs
@@ -5,6 +5,7 @@
  */
 
 use crate::SmartCalc;
+use crate::Session;
 use crate::compiler::date::DateItem;
 use crate::compiler::duration::DurationItem;
 use crate::compiler::dynamic_type::DynamicTypeItem;
@@ -16,6 +17,7 @@ use chrono::{Duration, NaiveDate, Utc};
 use chrono::{Datelike};
 use alloc::string::ToString;
 use core::ops::Deref;
+use core::cell::RefCell;
 
 #[test]
 fn execute_1() {
@@ -645,4 +647,74 @@ fn execute_35() {
         },
         _ => assert!(false)
     };
+}
+
+macro_rules! evaluate_line {
+    ($calc:ident, $input:literal => Err) => {
+        let res = $calc.execute("en".to_string(), $input.to_string());
+        assert_eq!(res.lines.len(), 1);
+        assert!(res.lines[0].as_ref().unwrap().result.as_ref().is_err());
+    };
+    ($calc:ident, $input:literal => $output:literal) => {
+        let res = $calc.execute("en".to_string(), $input.to_string());
+        assert_eq!(res.lines.len(), 1);
+        let output: &str = res.lines[0]
+            .as_ref()
+            .unwrap()
+            .result
+            .as_ref()
+            .unwrap()
+            .output
+            .as_ref();
+        assert_eq!(output, $output);
+    };
+    ($calc:ident with $session:ident, $input:literal => Err) => {
+        $session.borrow_mut().set_text($input.to_string());
+        let res = $calc.execute("en".to_string(), $input.to_string());
+        assert_eq!(res.lines.len(), 1);
+        assert!(res.lines[0].as_ref().unwrap().result.as_ref().is_err());
+    };
+    ($calc:ident with $session:ident, $input:literal => $output:literal) => {
+        $session.borrow_mut().set_text($input.to_string());
+        let res = $calc.execute_session(&$session);
+        assert_eq!(res.lines.len(), 1);
+        let output: &str = res.lines[0]
+            .as_ref()
+            .unwrap()
+            .result
+            .as_ref()
+            .unwrap()
+            .output
+            .as_ref();
+        assert_eq!(output, $output);
+    };
+}
+
+#[test]
+fn execute_session() {
+    let calc = SmartCalc::default();
+
+    // standard evaluation always uses a new session
+    evaluate_line!(calc, r"foo = 1" => r"1");
+    evaluate_line!(calc, r"bar = 2" => r"2");
+    evaluate_line!(calc, r"foo + bar" => Err);
+
+    let mut session = Session::new();
+    session.set_language("en".to_string());
+    let session = RefCell::new(session);
+
+    // persistent session should keep variables from previous evaluations
+    evaluate_line!(calc with session, r"foo = 1" => r"1");
+    evaluate_line!(calc with session, r"bar = 2" => r"2");
+    evaluate_line!(calc with session, r"foo + bar" => r"3");
+
+    // rebinding a variable should work too
+    evaluate_line!(calc with session, r"foo = 10" => r"10");
+    evaluate_line!(calc with session, r"foo + bar" => r"12");
+
+    // opening a new session should clear any previously set variables
+    let mut session = Session::new();
+    session.set_language("en".to_string());
+    let session = RefCell::new(session);
+    evaluate_line!(calc with session, r"foo + bar" => Err);
 }


### PR DESCRIPTION
Currently, `Smartcalc::App::execute` expects that all previous calculations are passed in with `data`. It uses `data` to create a new session each time `execute` is invoked, and discards the session before returning. This means that variables must be redefined, and all previous calculations must be re-run each time `execute` is invoked.

This PR proposes a new method, `execute_session`, that accepts a `Smartcalc::Session` instead of an input string and reuses the session. This allows for consumers (in my case, `smartcalc-tui`) to maintain a persistent session and call `execute_session` with only new input, maintaining any previously defined variables. This should be more efficient than calling `execute` with all previous calculations each time. The signature of `execute` is unchanged, so this proposed change is backwards-compatible.

You can see the intended usage [here](https://github.com/superhawk610/smartcalc-tui/pull/9). What do you think?