### PR TITLE
make `{UiToken, UiTokenType}` pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,3 +33,5 @@ pub use config::SmartCalcConfig;
 pub use types::SmartCalcAstType;
 pub use types::FieldType;
 pub use compiler::DataItem;
+pub use token::ui_token::UiToken;
+pub use token::ui_token::UiTokenType;


### PR DESCRIPTION
This will allow syntax highlighting support in non-JS contexts.

For `smartcalc-tui`, this should be easy to implement if I can match on `ResultLine.ui_tokens` and select a text color based on `ui_type`.